### PR TITLE
bug with ctrl+a

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install
 
 Start a terminal and type the following commands:
 
-    $ wget https://raw.github.com/orithena/clip2qr/master/clip2qr.sh -O /tmp/clip2qr.sh
+    $ wget https://raw.githubusercontent.com/AvatarBlueray/clip2qr-1/master/clip2qr.sh -O /tmp/clip2qr.sh
     $ sudo cp /tmp/clip2qr.sh /usr/local/bin
     $ sudo chmod +x /usr/local/bin/clip2qr.sh
     

--- a/clip2qr.sh
+++ b/clip2qr.sh
@@ -34,14 +34,17 @@ trap 'rm -rf $TMPDIR; exit 1' 0 1 2 3 13 15
 # First, try to convert data from clipboard and push it into tempdir
 
 # check if primary clipboard contains convertible data
-if xclip -o | qrencode -s 2 -m 2 -o - > $TMPDIR/qrcode.png
-then 
-    TXT=$(xclip -o)
+
 
 # check if clipboard contains convertible data
-elif xclip -o -selection clipboard | qrencode -s 2 -m 2 -o - > $TMPDIR/qrcode.png
+
+
+if xclip -o -selection clipboard | qrencode -s 2 -m 2 -o - > $TMPDIR/qrcode.png
 then
-    TXT=$(xclip -o -selection clipboard)
+    TXT=$(xclip -o -selection clipboard)    
+elif xclip -o | qrencode -s 2 -m 2 -o - > $TMPDIR/qrcode.png
+then 
+    TXT=$(xclip -o)     
 
 # no convertible data found -> notify user (maybe you need to insert your notificator of choice here)
 else


### PR DESCRIPTION
step to reproduce

open text editor, as example kate
write two lines, select one with mouse than ctrl+c,  than ctrl+a, ctrl+c, than run script. You will see one line selected by mouse.

this commit fix this problem/